### PR TITLE
feat: Clean hard coded tagIds in referencesMany

### DIFF
--- a/lib/property.ts
+++ b/lib/property.ts
@@ -102,11 +102,14 @@ export function Embedded(fn: any) {
 }
 
 export const referencesManyCache = {};
-export function ReferencesMany(fn: any) {
+export function ReferencesMany(
+  fn: any,
+  options: { from: string; to?: string },
+) {
   return (target: object, propertyKey: string | symbol) => {
     referencesManyCache[target.constructor.name] = {
       ...(referencesManyCache[target.constructor.name] || {}),
-      [propertyKey]: fn,
+      [propertyKey]: { fn, ...options },
     };
   };
 }

--- a/lib/resolvers/crud.resolver.ts
+++ b/lib/resolvers/crud.resolver.ts
@@ -35,7 +35,8 @@ export function createResolver(definition: Definition): Provider {
       const created = await this.model.create(input);
       for (const propertyName in referencesManyCache[definition.name] || {}) {
         if (!input[propertyName] || input[propertyName].length === 0) continue;
-        const relationDefinition = referencesManyCache[definition.name][propertyName].fn();
+        const relationDefinition =
+          referencesManyCache[definition.name][propertyName].fn();
         const newIds: string[] = [];
         for (const subObject of input[propertyName]) {
           const relationModel = this.moduleRef.get(

--- a/lib/resolvers/crud.resolver.ts
+++ b/lib/resolvers/crud.resolver.ts
@@ -35,8 +35,7 @@ export function createResolver(definition: Definition): Provider {
       const created = await this.model.create(input);
       for (const propertyName in referencesManyCache[definition.name] || {}) {
         if (!input[propertyName] || input[propertyName].length === 0) continue;
-        const relationDefinition =
-          referencesManyCache[definition.name][propertyName]();
+        const relationDefinition = referencesManyCache[definition.name][propertyName].fn();
         const newIds: string[] = [];
         for (const subObject of input[propertyName]) {
           const relationModel = this.moduleRef.get(

--- a/lib/resolvers/references-many.resolver.ts
+++ b/lib/resolvers/references-many.resolver.ts
@@ -12,7 +12,8 @@ export function createResolverForReferencesMany(
   definition: Definition,
   field: string,
 ): Provider {
-  const relationDefinition = referencesManyCache[definition.name][field]();
+  const relation = referencesManyCache[definition.name][field];
+  const relationDefinition = relation.fn();
 
   @Resolver(() => Typer.getObjectType(definition))
   class GeneratedResolverForReferencesMany<T> {
@@ -23,7 +24,7 @@ export function createResolverForReferencesMany(
     @ResolveField()
     async [field](@Parent() parent: any): Promise<T[]> {
       const items = await this.model.find({
-        _id: { $in: parent['tagIds'] },
+        [relation.to || '_id']: { $in: parent[relation.from] },
       });
       return items.map((item) =>
         appendIdAndTransform(relationDefinition, item),

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -42,7 +42,7 @@ export class Product {
   )
   tagIds: string[];
 
-  @ReferencesMany(() => Tag)
+  @ReferencesMany(() => Tag, { from: 'tagIds' })
   @Property(() => [Typer.getCreateInputType(Tag)], { nullable: true })
   @OutputProperty(() => [Typer.getObjectType(Tag)])
   tags: Tag[];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows conventional commit format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #55


## What is the new behavior?
ReferenceMany usage change:
Old
```typescript
@ReferencesMany(() => Tag)
tags: Tag[];
```

New
```typescript
@ReferencesMany(() => Tag, { from: 'tagIds' })
tags: Tag[];
```
## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

